### PR TITLE
Integrate with Convenient Chests

### DIFF
--- a/MegaStorage/IConvenientChestsAPI.cs
+++ b/MegaStorage/IConvenientChestsAPI.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using StardewValley.Objects;
+
+namespace MegaStorage
+{
+    public interface IConvenientChestsAPI
+    {
+        void CopyChestData(Chest source, Chest target);
+    }
+}

--- a/MegaStorage/MegaStorage.csproj
+++ b/MegaStorage/MegaStorage.csproj
@@ -68,6 +68,8 @@
     <Compile Include="Mapping\MappingExtensions.cs" />
     <Compile Include="Models\SaveData.cs" />
     <Compile Include="Persistence\SaveManager.cs" />
+    <Compile Include="IConvenientChestsAPI.cs" />
+    <Compile Include="MockConvenientChestsAPI.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Sprites\LargeChest.png">

--- a/MegaStorage/MegaStorageMod.cs
+++ b/MegaStorage/MegaStorageMod.cs
@@ -27,15 +27,25 @@ namespace MegaStorage
 
         private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
         {
+            IConvenientChestsAPI convenientChestsAPI = Helper.ModRegistry.GetApi<IConvenientChestsAPI>("aEnigma.ConvenientChests");
+            if (convenientChestsAPI != null)
+            {
+                Monitor.Log("Convenient Chests found, integration enabled");
+            }
+            else
+            {
+                convenientChestsAPI = new MockConvenientChestsAPI();
+            }
+
             var itemPatcher = new ItemPatcher(Helper, Monitor);
             var spritePatcher = new SpritePatcher(Helper, Monitor);
             var farmhandMonitor = new FarmhandMonitor(Helper, Monitor);
             var savers = new ISaver[]
             {
-                new InventorySaver(Helper, Monitor),
-                new FarmhandInventorySaver(Helper, Monitor),
-                new LocationSaver(Helper, Monitor),
-                new LocationInventorySaver(Helper, Monitor)
+                new InventorySaver(Helper, Monitor, convenientChestsAPI),
+                new FarmhandInventorySaver(Helper, Monitor, convenientChestsAPI),
+                new LocationSaver(Helper, Monitor, convenientChestsAPI),
+                new LocationInventorySaver(Helper, Monitor, convenientChestsAPI)
             };
             var saveManager = new SaveManager(Helper, Monitor, farmhandMonitor, savers);
 

--- a/MegaStorage/MockConvenientChestsAPI.cs
+++ b/MegaStorage/MockConvenientChestsAPI.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using StardewValley.Objects;
+
+namespace MegaStorage
+{
+    public class MockConvenientChestsAPI : IConvenientChestsAPI
+    {
+        public void CopyChestData(Chest source, Chest target)
+        {
+        }
+    }
+}

--- a/MegaStorage/Persistence/FarmhandInventorySaver.cs
+++ b/MegaStorage/Persistence/FarmhandInventorySaver.cs
@@ -14,13 +14,14 @@ namespace MegaStorage.Persistence
 
         private readonly IModHelper _modHelper;
         private readonly IMonitor _monitor;
-
+        private readonly IConvenientChestsAPI _convenientChestsAPI;
         private Dictionary<long, Dictionary<int, CustomChest>> _farmhandInventoryCustomChests;
 
-        public FarmhandInventorySaver(IModHelper modHelper, IMonitor monitor)
+        public FarmhandInventorySaver(IModHelper modHelper, IMonitor monitor, IConvenientChestsAPI convenientChestsAPI)
         {
             _modHelper = modHelper;
             _monitor = monitor;
+            _convenientChestsAPI = convenientChestsAPI;
         }
 
         public void HideAndSaveCustomChests()
@@ -38,6 +39,7 @@ namespace MegaStorage.Persistence
                 {
                     var chest = customChest.ToChest();
                     var index = player.Items.IndexOf(customChest);
+                    _convenientChestsAPI.CopyChestData(customChest, chest);
                     player.Items[index] = chest;
                     var deserializedChest = customChest.ToDeserializedChest(playerId, index);
                     _monitor.VerboseLog($"Hiding and saving: {deserializedChest}");
@@ -111,6 +113,7 @@ namespace MegaStorage.Persistence
                 var chest = (Chest)player.Items[deserializedChest.InventoryIndex];
                 var customChest = chest.ToCustomChest(deserializedChest.ChestType);
                 _monitor.VerboseLog($"Loading: {deserializedChest}");
+                _convenientChestsAPI.CopyChestData(chest, customChest);
                 player.Items[deserializedChest.InventoryIndex] = customChest;
             }
         }

--- a/MegaStorage/Persistence/InventorySaver.cs
+++ b/MegaStorage/Persistence/InventorySaver.cs
@@ -14,13 +14,14 @@ namespace MegaStorage.Persistence
 
         private readonly IModHelper _modHelper;
         private readonly IMonitor _monitor;
-
+        private readonly IConvenientChestsAPI _convenientChestsAPI;
         private Dictionary<int, CustomChest> _inventoryCustomChests;
 
-        public InventorySaver(IModHelper modHelper, IMonitor monitor)
+        public InventorySaver(IModHelper modHelper, IMonitor monitor, IConvenientChestsAPI convenientChestsAPI)
         {
             _modHelper = modHelper;
             _monitor = monitor;
+            _convenientChestsAPI = convenientChestsAPI;
         }
 
         public void HideAndSaveCustomChests()
@@ -33,6 +34,7 @@ namespace MegaStorage.Persistence
             {
                 var chest = customChest.ToChest();
                 var index = Game1.player.Items.IndexOf(customChest);
+                _convenientChestsAPI.CopyChestData(customChest, chest);
                 Game1.player.Items[index] = chest;
                 var deserializedChest = customChest.ToDeserializedChest(index);
                 _monitor.VerboseLog($"Hiding and saving: {deserializedChest}");
@@ -88,6 +90,7 @@ namespace MegaStorage.Persistence
                 var chest = (Chest)Game1.player.Items[deserializedChest.InventoryIndex];
                 var customChest = chest.ToCustomChest(deserializedChest.ChestType);
                 _monitor.VerboseLog($"Loading: {deserializedChest}");
+                _convenientChestsAPI.CopyChestData(chest, customChest);
                 Game1.player.Items[deserializedChest.InventoryIndex] = customChest;
             }
 

--- a/MegaStorage/Persistence/LocationInventorySaver.cs
+++ b/MegaStorage/Persistence/LocationInventorySaver.cs
@@ -15,13 +15,14 @@ namespace MegaStorage.Persistence
 
         private readonly IModHelper _modHelper;
         private readonly IMonitor _monitor;
-
+        private readonly IConvenientChestsAPI _convenientChestsAPI;
         private Dictionary<GameLocation, Dictionary<Vector2, Dictionary<int, CustomChest>>> _locationInventoryCustomChests;
 
-        public LocationInventorySaver(IModHelper modHelper, IMonitor monitor)
+        public LocationInventorySaver(IModHelper modHelper, IMonitor monitor, IConvenientChestsAPI convenientChestsAPI)
         {
             _modHelper = modHelper;
             _monitor = monitor;
+            _convenientChestsAPI = convenientChestsAPI;
         }
 
         public void HideAndSaveCustomChests()
@@ -48,6 +49,7 @@ namespace MegaStorage.Persistence
                     foreach (var customChest in customChestsInChest)
                     {
                         var index = chest.items.IndexOf(customChest);
+                        _convenientChestsAPI.CopyChestData(customChest, chest);
                         chest.items[index] = customChest.ToChest();
                         customChestIndexes.Add(index, customChest);
                         var deserializedChest = customChest.ToDeserializedChest(locationName, position, index);
@@ -130,6 +132,7 @@ namespace MegaStorage.Persistence
                     var hiddenCustomChest = (Chest)chest.items[index];
                     var customChest = hiddenCustomChest.ToCustomChest(deserializedChest.ChestType);
                     _monitor.VerboseLog($"Loading: {deserializedChest}");
+                    _convenientChestsAPI.CopyChestData(chest, customChest);
                     chest.items[index] = customChest;
                 }
             }

--- a/MegaStorage/Persistence/LocationSaver.cs
+++ b/MegaStorage/Persistence/LocationSaver.cs
@@ -15,13 +15,14 @@ namespace MegaStorage.Persistence
 
         private readonly IModHelper _modHelper;
         private readonly IMonitor _monitor;
-
+        private readonly IConvenientChestsAPI _convenientChestsAPI;
         private Dictionary<GameLocation, Dictionary<Vector2, CustomChest>> _locationCustomChests;
 
-        public LocationSaver(IModHelper modHelper, IMonitor monitor)
+        public LocationSaver(IModHelper modHelper, IMonitor monitor, IConvenientChestsAPI convenientChestsAPI)
         {
             _modHelper = modHelper;
             _monitor = monitor;
+            _convenientChestsAPI = convenientChestsAPI;
         }
 
         public void HideAndSaveCustomChests()
@@ -42,6 +43,7 @@ namespace MegaStorage.Persistence
                     var position = customChestPosition.Key;
                     var customChest = customChestPosition.Value;
                     var chest = customChest.ToChest();
+                    _convenientChestsAPI.CopyChestData(customChest, chest);
                     location.objects[position] = chest;
                     var deserializedChest = customChest.ToDeserializedChest(locationName, position);
                     _monitor.VerboseLog($"Hiding and saving in {locationName}: {deserializedChest}");
@@ -113,6 +115,7 @@ namespace MegaStorage.Persistence
                     var chest = (Chest)location.objects[position];
                     var customChest = chest.ToCustomChest(deserializedChest.ChestType);
                     _monitor.VerboseLog($"Loading: {deserializedChest}");
+                    _convenientChestsAPI.CopyChestData(chest, customChest);
                     location.objects[position] = customChest;
                 }
             }

--- a/MegaStorage/manifest.json
+++ b/MegaStorage/manifest.json
@@ -6,5 +6,12 @@
   "UniqueID": "Alek.MegaStorage",
   "EntryDll": "MegaStorage.dll",
   "MinimumApiVersion": "2.10.0",
-  "UpdateKeys": [ "Nexus:4089" ]
+  "UpdateKeys": [ "Nexus:4089" ],
+  "Dependencies": [
+    {
+      "UniqueID": "aEnigma.ConvenientChests",
+      "MinimumVersion": "1.1.1",
+      "IsRequired": false
+    }
+  ]
 }


### PR DESCRIPTION
This resolves the problem of the categories not being saved for chests added by MegaStorage. The cause of the problem is that Convenient Chests has an internal mapping of chest -> data. While saving, all MegaStorage chests are temporarily replaced with regular chests, which do not have the same data mapped to them.

This change makes use of a new API in Convenient Chests (which is still pending, see [PR](https://github.com/aEnigmatic/StardewValley/pull/3)) which allows us to copy this data to and from these temporary chests.